### PR TITLE
Добавление имени сети в сообщении для отладки.

### DIFF
--- a/firmware/GyverTwink_v1.2/startup.ino
+++ b/firmware/GyverTwink_v1.2/startup.ino
@@ -44,7 +44,9 @@ void setupAP() {
 }
 
 void setupSTA() {
-  DEBUG("Connecting to AP... ");
+  DEBUG("Connecting to ");
+  DEBUG(portalCfg.SSID);
+  DEBUG(" ... ");
   WiFi.softAPdisconnect();
   WiFi.disconnect();
   WiFi.mode(WIFI_STA);


### PR DESCRIPTION
Добавление имени сети для отладки.

т.к. ДА, не очевидно, что допустил ошибку в названии, когда не видно какие сети есть! %( 

p.s.: В портале пробовал перечислить доступные сети, но сдался на преобразовании типов в webServer.sendContent.

Возможно, уже есть версия, где вместо поля для ввода имени сети есть select? Либо просто список доступных сетей...